### PR TITLE
Add postgres role configuration step to local setup guide

### DIFF
--- a/.claude/skills/setup-local-postgres.md
+++ b/.claude/skills/setup-local-postgres.md
@@ -26,6 +26,11 @@ brew services start postgresql@16
 pg_isready -h localhost
 ```
 
+**Configure postgres role with superuser and default password:**
+```bash
+sudo -u postgres psql -c "ALTER USER postgres WITH SUPERUSER PASSWORD 'postgres';"
+```
+
 ## Step 2: Initialize Database with Supabase Schema
 
 Use the official Supabase migration scripts to set up the database schema:


### PR DESCRIPTION
## Summary
Updated the local PostgreSQL setup documentation to include an explicit step for configuring the postgres role with superuser privileges and setting a default password.

## Changes
- Added a new configuration step after PostgreSQL service startup that:
  - Grants superuser privileges to the postgres role
  - Sets the default password to 'postgres' for local development
  - Uses the standard `psql` command for role configuration

## Details
This addition clarifies the necessary role setup for local development environments and ensures the postgres user has the appropriate permissions before initializing the Supabase schema in Step 2. The default password 'postgres' is a common convention for local development setups and should not be used in production environments.

https://claude.ai/code/session_01FPRsfRAaKYggbk58vxsNrz